### PR TITLE
add new golfer page based on user_id

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -11,7 +11,11 @@ const Layout = ({ children }) => {
       <header className="flex flex-row w-full px-10 py-2 shadow">
         <span className="h-8 items-center space-x-6">
           <span className="text-2xl">Golfr 🏌️</span>
-          <span className="text-xl">Home</span>
+          <span className="text-xl">
+            <Link href="/">
+              Home
+            </Link>
+          </span>
         </span>
         <span className="h-8 items-center text-xl ml-auto">
           {username}

--- a/components/ScoreCard.js
+++ b/components/ScoreCard.js
@@ -5,7 +5,7 @@ import Link from 'next/link'
 
 const CONFIRM_MESSAGE = 'Are you sure you want to delete the score?'
 
-const ScoreCard = ({ id, playedAt, totalScore, userId, userName, showUserLink = false }) => {
+const ScoreCard = ({ id, playedAt, totalScore, userId, userName, showUserLink = true }) => {
   const { deleteScore } = useScoreDelete(id)
 
   return (
@@ -15,14 +15,14 @@ const ScoreCard = ({ id, playedAt, totalScore, userId, userName, showUserLink = 
           {playedAt}
         </div>
         <div>
-          {!showUserLink &&
+          {showUserLink &&
             <Link href={`/golfers/${userId}`}>
               <a>
-                {`${userName} : `}
+                {`${userName}`}
               </a>
             </Link>
           }
-          {`${userName} posted a score of ${totalScore}`}
+          {` posted a score of ${totalScore}`}
         </div>
       </div>
       <div className="w-1/6">

--- a/components/ScoreCard.js
+++ b/components/ScoreCard.js
@@ -5,7 +5,7 @@ import Link from 'next/link'
 
 const CONFIRM_MESSAGE = 'Are you sure you want to delete the score?'
 
-const ScoreCard = ({ id, playedAt, totalScore, userId, userName, showUserLink = true }) => {
+const ScoreCard = ({ id, playedAt, totalScore, userId, userName, userLinkAvailable = true }) => {
   const { deleteScore } = useScoreDelete(id)
 
   return (
@@ -15,14 +15,19 @@ const ScoreCard = ({ id, playedAt, totalScore, userId, userName, showUserLink = 
           {playedAt}
         </div>
         <div>
-          {showUserLink &&
-            <Link href={`/golfers/${userId}`}>
-              <a>
-                {`${userName}`}
-              </a>
-            </Link>
+          {userLinkAvailable ? (
+            <>
+              <Link href={`/golfers/${userId}`}>
+                <a>
+                  {`${userName}`}
+                </a>
+              </Link>
+              {` posted a score of ${totalScore}`}
+            </>
+          ) : (
+            `${userName} posted a score of ${totalScore}`
+          )
           }
-          {` posted a score of ${totalScore}`}
         </div>
       </div>
       <div className="w-1/6">

--- a/components/ScoreCard.js
+++ b/components/ScoreCard.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types'
 import useScoreDelete from '../lib/useScoreDelete'
 import { getUserId } from '../lib/userAuth'
+import Link from 'next/link'
 
 const CONFIRM_MESSAGE = 'Are you sure you want to delete the score?'
 
-const ScoreCard = ({ id, playedAt, totalScore, userId, userName }) => {
+const ScoreCard = ({ id, playedAt, totalScore, userId, userName, showUserLink = false }) => {
   const { deleteScore } = useScoreDelete(id)
 
   return (
@@ -14,6 +15,13 @@ const ScoreCard = ({ id, playedAt, totalScore, userId, userName }) => {
           {playedAt}
         </div>
         <div>
+          {!showUserLink &&
+            <Link href={`/golfers/${userId}`}>
+              <a>
+                {`${userName} : `}
+              </a>
+            </Link>
+          }
           {`${userName} posted a score of ${totalScore}`}
         </div>
       </div>

--- a/lib/useUserScores.js
+++ b/lib/useUserScores.js
@@ -1,7 +1,7 @@
 import useSWR from 'swr'
 import { getToken } from './userAuth'
 
-export const SCORES_URL = userId => `${process.env.NEXT_PUBLIC_API_URL}/scores/${userId}`
+export const SCORES_URL = userId => `${process.env.NEXT_PUBLIC_API_URL}/users/${userId}/scores`
 
 const useUserScores = userId => {
 

--- a/lib/useUserScores.js
+++ b/lib/useUserScores.js
@@ -1,0 +1,31 @@
+import useSWR from 'swr'
+import { getToken } from './userAuth'
+
+export const SCORES_URL = userId => `${process.env.NEXT_PUBLIC_API_URL}/scores/${userId}`
+
+const useUserScores = userId => {
+
+  const fetcher = async url => {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${getToken()}`,
+      },
+    })
+
+    if (!res.ok){
+      const error = new Error('An error occured while fetching the data for this user')
+
+      error.info = await res.json()
+      error.status = res.status
+      throw error
+    }
+
+    return res.json()
+  }
+  const { data, error } = useSWR(userId ? SCORES_URL(userId) : null, fetcher)
+
+  return { data, error }
+}
+
+export default useUserScores

--- a/pages/golfers/[id].js
+++ b/pages/golfers/[id].js
@@ -39,7 +39,7 @@ const GolferPage = () => {
                 playedAt={score.played_at}
                 userId={score.user_id}
                 userName={user.name}
-                showUserLink={true}
+                showUserLink={false}
               />
             ))}
           </>

--- a/pages/golfers/[id].js
+++ b/pages/golfers/[id].js
@@ -1,0 +1,52 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import Layout from '../../components/Layout'
+import ScoreCard from '../../components/ScoreCard'
+import useUserScores from '../../lib/useUserScores'
+
+const GolferPage = () => {
+
+  const [ user, setUser ] = useState({})
+  const [ scores, setScores ] = useState([])
+  const route = useRouter()
+  const { id } = route.query
+  const { data, error } = useUserScores(id)
+
+  useEffect(() => {
+    if (data){
+      setUser(data.user)
+      setScores(data.scores)
+    }
+  }, [ data ])
+
+  if (!data && !error){
+    return <p>Loading...</p>
+  }
+
+  return (
+    <Layout>
+      { error ? (
+        error.info.errors
+      ) : (
+        user.name && (
+          <>
+            <h1> The scores of user {user.name}: </h1>
+            {scores && scores.map(score => (
+              <ScoreCard
+                key={score.id}
+                id={score.id}
+                totalScore={score.total_score}
+                playedAt={score.played_at}
+                userId={score.user_id}
+                userName={user.name}
+                showUserLink={true}
+              />
+            ))}
+          </>
+        )
+      )}
+    </Layout>
+  )
+}
+
+export default GolferPage

--- a/pages/golfers/[id].js
+++ b/pages/golfers/[id].js
@@ -39,7 +39,7 @@ const GolferPage = () => {
                 playedAt={score.played_at}
                 userId={score.user_id}
                 userName={user.name}
-                showUserLink={false}
+                userLinkAvailable={false}
               />
             ))}
           </>


### PR DESCRIPTION
Fixes: #2

**Changes**

New dynamic route was added under **pages/golfers/[id].js**.
New custom hook added under lib folder called **useUserScores**. This hook will be called in [id].js file in order to get the user selected and the scores which belong to him.
The component **components/ScoreCard** was modified to show the users name that could be selected in the home page. In [id].js it will not show the users because we are using a default prop based on we'll decide If we are showing the users or not. ( We don't need to show users + their links in dynamic page because we already know which user we selected before.


**Before**

We have no changes before because this task is a feature

**After**

Screenshot after the change.
There is the main page where someone can see all user scores.
<img width="1776" alt="Screenshot 2022-01-14 at 12 44 01" src="https://user-images.githubusercontent.com/96296162/149503223-c72019ac-0f29-488e-bc17-347c65bb82c8.png">
Now, clicking on username from this page you will be redirected to golfer/[id] page because a link was added to the username. When username is clicked browser will forward the golfer page using his id.

After clicking one username:

<img width="1773" alt="Screenshot 2022-01-14 at 13 32 20" src="https://user-images.githubusercontent.com/96296162/149508928-6e717172-dd13-474f-913a-8ef112e3e04f.png">

